### PR TITLE
Refactoring referrals for privacy concerns

### DIFF
--- a/index.php
+++ b/index.php
@@ -57,7 +57,15 @@ if (intval($from_id) != 0) {
     } else {
         $verify = 1;
     }
-    $ref_code = bin2hex(random_bytes(16)); // 32-hex-char string
+
+    do {
+        $ref_code = bin2hex(random_bytes(16));
+        $stmt_check = $pdo->prepare("SELECT 1 FROM user WHERE ref_code = :ref_code");
+        $stmt_check->bindParam(':ref_code', $ref_code);
+        $stmt_check->execute();
+
+    } while ($stmt_check->fetchColumn());
+
     $stmt = $pdo->prepare(
         "INSERT IGNORE INTO user
             (id, ref_code, step, limit_usertest, User_Status, number, Balance,

--- a/table.php
+++ b/table.php
@@ -13,6 +13,7 @@ try {
     if (!$table_exists) {
         $result = $connect->query("CREATE TABLE user (
         id varchar(500)  PRIMARY KEY,
+        ref_code CHAR(32) NOT NULL UNIQUE, 
         limit_usertest int(100) NOT NULL,
         roll_Status bool NOT NULL,
         Processing_value  TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
@@ -49,6 +50,21 @@ try {
         addFieldToTable($tableName, 'Processing_value_one', '0',"VARCHAR(1000)");
         addFieldToTable($tableName, 'roll_Status','false',"bool");
         addFieldToTable($tableName, 'Processing_value_four', '0',"VARCHAR(100)");
+        addFieldToTable($tableName, 'ref_code', '', "CHAR(32)");
+        $result_ref = $connect->query("SELECT id FROM user WHERE ref_code IS NULL OR ref_code = ''");
+        if ($result_ref && $result_ref->num_rows > 0) {
+            while ($row = $result_ref->fetch_assoc()) {
+                $id = $row['id'];
+                $new_ref_code = str_replace('-', '', sprintf(
+                    '%04x%04x%04x%04x%04x%04x%04x%04x',
+                    mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+                    mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+                    mt_rand(0, 0xffff), mt_rand(0, 0xffff),
+                    mt_rand(0, 0xffff), mt_rand(0, 0xffff)
+                ));
+                $connect->query("UPDATE user SET ref_code = '$new_ref_code' WHERE id = '$id'");
+            }
+        }
         }
 } catch (Exception $e) {
     file_put_contents("$randomString.txt",$e->getMessage());


### PR DESCRIPTION
This PR retires the outdated Telegram ID-based referral system and introduces a secure, privacy-first referral code mechanism. It’s a foundational shift toward a more robust architecture—while preserving full backward compatibility. Legacy referrals continue to work seamlessly.

What’s new:

1. Introduced a ref_code column in the users table. Unique referral codes have been retroactively generated for all existing users.
2. Referral links now use these new codes instead of exposing internal user IDs.
3. Legacy numeric ID-based links remain supported to ensure zero disruption during transition.
4. This change strengthens user privacy, prepares the system for scale, and future-proofs the referral infrastructure.

-----

به طور کلی توی این تغییر، استفاده از آیدی تلگرام برای لینک ریفر کنار گذاشته شد بخاطر مشکلات حریم خصوصی (شاید یکی نخواد ایدیش تو لینک ریفرش لو بره). به جاش یک عدد یونیک رندوم میاد که هر کاربر یه کد مخصوص به خودش داره. هم امن‌تره، هم آبرومندتره
لینک‌های قبلی هنوز درست کار می‌کنن، پس هیچ چیزی نمی‌پره یا خراب نمی‌شه.