### PR TITLE
Fix: Use correct variables in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1258,7 +1258,7 @@ EOF
 
     # Send confirmation message
     MESSAGE="✅ The bot is installed! for start bot send comment /start"
-    curl -s -X POST "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" -d chat_id="${CHAT_ID}" -d text="$MESSAGE" || {
+    curl -s -X POST "https://api.telegram.org/bot${YOUR_BOT_TOKEN}/sendMessage" -d chat_id="${YOUR_CHAT_ID}" -d text="$MESSAGE" || {
         echo -e "\033[31mError: Failed to send message to Telegram.\033[0m"
         return 1
     }


### PR DESCRIPTION
The install_bot_with_marzban function was using undefined variables ${BOT_TOKEN} and ${CHAT_ID} when sending a Telegram notification upon successful installation.

This change corrects the variable names to ${YOUR_BOT_TOKEN} and ${YOUR_CHAT_ID}, which are correctly populated with user input earlier in the script. This ensures the confirmation message is sent as intended.